### PR TITLE
BugFix: correctly destroy dockable map widgets on profile close

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -159,6 +159,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mCommandLineFgColor(Qt::darkGray)
 , mCommandLineBgColor(Qt::black)
 , mFORCE_MXP_NEGOTIATION_OFF(false)
+, mpDockableMapWidget()
 , mHaveMapperScript(false)
 {
    // mLogStatus = mudlet::self()->mAutolog;
@@ -190,6 +191,9 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 
 Host::~Host()
 {
+    if (mpDockableMapWidget) {
+        mpDockableMapWidget->deleteLater();
+    }
     mIsGoingDown = true;
     mIsClosingDown = true;
     mTelnet.disconnect();

--- a/src/Host.h
+++ b/src/Host.h
@@ -42,6 +42,7 @@
 #include "post_guard.h"
 
 class QDialog;
+class QDockWidget;
 class QPushButton;
 class QListWidget;
 
@@ -303,6 +304,7 @@ public:
     bool mMapperUseAntiAlias;
     bool mFORCE_MXP_NEGOTIATION_OFF;
     QSet<QChar> mDoubleClickIgnore;
+    QPointer<QDockWidget> mpDockableMapWidget;
 
 private:
     QScopedPointer<LuaInterface> mLuaInterface;

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2170,21 +2170,26 @@ void mudlet::slot_mapper()
 void mudlet::createMapper( bool isToLoadDefaultMapFile )
 {
     Host * pHost = getActiveHost();
-    if( ! pHost ) return;
+    if( ! pHost )
+    {
+        return;
+    }
     if( pHost->mpMap->mpMapper )
     {
         bool visStatus = pHost->mpMap->mpMapper->isVisible();
         if ( pHost->mpMap->mpMapper->parentWidget()->inherits("QDockWidget") )
+        {
             pHost->mpMap->mpMapper->parentWidget()->setVisible( !visStatus );
+        }
         pHost->mpMap->mpMapper->setVisible( !visStatus );
         return;
     }
 
-    QDockWidget * pDock = new QDockWidget( tr("Map - %1").arg(pHost->getName()) );
-    pDock->setObjectName( QString("dockMap_%1").arg(pHost->getName()) );
-    pHost->mpMap->mpMapper = new dlgMapper( pDock, pHost, pHost->mpMap.data() );//FIXME: mpHost definieren
+    pHost->mpDockableMapWidget = new QDockWidget( tr("Map - %1").arg(pHost->getName()) );
+    pHost->mpDockableMapWidget->setObjectName( QString("dockMap_%1").arg(pHost->getName()) );
+    pHost->mpMap->mpMapper = new dlgMapper( pHost->mpDockableMapWidget, pHost, pHost->mpMap.data() );//FIXME: mpHost definieren
     pHost->mpMap->mpM = pHost->mpMap->mpMapper->glWidget;
-    pDock->setWidget( pHost->mpMap->mpMapper );
+    pHost->mpDockableMapWidget->setWidget( pHost->mpMap->mpMapper );
 
     if( isToLoadDefaultMapFile && pHost->mpMap->mpRoomDB->getRoomIDList().isEmpty() )
     {
@@ -2209,7 +2214,7 @@ void mudlet::createMapper( bool isToLoadDefaultMapFile )
             pHost->mpMap->mpMapper->show();
         }
     }
-    addDockWidget(Qt::RightDockWidgetArea, pDock);
+    addDockWidget(Qt::RightDockWidgetArea, pHost->mpDockableMapWidget);
 
     loadWindowLayout();
 


### PR DESCRIPTION
It has been a long-standing __fatal__ issue: https://github.com/Mudlet/Mudlet/issues/550 that dock-able mapper widgets were left orphaned with dangerously dangling pointers that will crash Mudlet when a profile using them was closed whilst multi-playing.  This commit makes the `Host` class now maintain a `QPointer` that tracks the `QDockWidget` that this type of map has, and, as part of the `Host` destructor ensures that the widget is given suicide instructions when the `Host` instance is, itself, killed.

A `QPointer` was used so that should the map widget somehow get deleted by other future code changes the pointer will automagically null itself so that a test for it being non-null in the `Host` destructor is sufficient to ensure that there is a widget that needs to be killed off at that time.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>