### PR TITLE
revise: use new Host::writeProfileData(...) method

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1268,3 +1268,22 @@ void Host::readPackageConfig(const QString& luaConfig, QString& packageName)
         lua_close(L);
     }
 }
+
+// Derived from the one in dlgConnectionProfile class - but it does not need a
+// host name argument...
+QPair<bool, QString> Host::writeProfileData(const QString & item, const QString & what)
+{
+    QFile file( QStringLiteral( "%1/.config/mudlet/profiles/%2/%3" )
+                .arg(QDir::homePath(), getName(), item) );
+    if (file.open( QIODevice::WriteOnly | QIODevice::Unbuffered )) {
+        QDataStream ofs( & file );
+        ofs << what;
+        file.close();
+    }
+
+    if (file.error() == QFile::NoError) {
+        return qMakePair(true, QString());
+    } else {
+        return qMakePair(false, file.errorString());
+    }
+}

--- a/src/Host.h
+++ b/src/Host.h
@@ -174,6 +174,7 @@ public:
     bool removeDir(const QString&, const QString&);
     void readPackageConfig(const QString&, QString&);
     void postMessage(const QString message) { mTelnet.postMessage(message); }
+    QPair<bool, QString> writeProfileData(const QString &, const QString &);
 
 public:
     cTelnet mTelnet;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3972,80 +3972,72 @@ int TLuaInterpreter::setRoomWeight( lua_State *L )
     return 0;
 }
 
-int TLuaInterpreter::connectToServer( lua_State *L )
+int TLuaInterpreter::connectToServer(lua_State* L)
 {
-    int port;
+    // The lua_tointeger(...) call can return a 64-bit integer number, on
+    // Windows Platform that is bigger than the int32_t type (a.k.a. "int" AND
+    // "long" types on that platform)! 8-O
+    lua_Integer port = 23;
     string url;
-    bool saveToProfile = false;
+    bool isToSaveToProfile = false;
 
-    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
-
-    if( ! lua_isstring( L, 1 ) )
-    {
-        lua_pushstring( L, QString(" connectToServer: argument #1 expects type string, %1 was given.").arg( lua_typename(L,1) ).toUtf8().constData() );
-        return lua_error( L );
-    }
-    else
-    {
-        url = lua_tostring( L, 1 );
+    Host* pHost = TLuaInterpreter::luaInterpreterMap[L];
+    if (!pHost) {
+        lua_pushstring(L, "connectToServer: NULL Host pointer - something is wrong!");
+        return lua_error(L);
     }
 
-    if( ! lua_isnumber( L, 2 ) )
-    {
-        lua_pushstring( L, QString(" connectToServer: argument #2 expects type int, %1 was given.").arg( lua_typename(L,2) ).toUtf8().constData() );
-        return lua_error( L );
+    if (!lua_isstring(L, 1)) {
+        lua_pushfstring(L, "connectToServer: bad argument #1 type (url as string expected, got %s!)", lua_typename(L, 1));
+        return lua_error(L);
+    } else {
+        url = lua_tostring(L, 1);
     }
-    else
-    {
-        port = lua_tonumber( L, 2 );
 
-        if( port > 65535 || port < 0 )
-        {
-            lua_pushstring( L, " connectToServer: argument #2 is invalid, a valid port number is required.");
+    if (!lua_isnoneornil(L, 2)) {
+        if (!lua_isnumber(L, 2)) {
+            lua_pushfstring(L, "connectToServer: bad argument #2 type (port number as number is optional {default = 23}, got %s!)", lua_typename(L, 2));
             return lua_error(L);
+        } else {
+            port = lua_tointeger(L, 2);
+            if (port > 65535 || port < 1) {
+                lua_pushnil(L);
+                lua_pushfstring(L, "invalid port number %d given, if supplied it must be in range 1 to 65535, {defaults to 23 if not provided}", port);
+                return 2;
+            }
         }
     }
 
     // Optional argument to save this new connection to disk for this profile.
-    if( !lua_isnoneornil(L,3) && !lua_isboolean(L,3) ) {
-        lua_pushstring( L, QString(" connectToServer: argument #3 expects boolean type, %1 was given.").arg( lua_typename(L,3) ).toUtf8().constData() );
-        return lua_error(L);
-    }
-    if( ! lua_isnoneornil(L,3) && lua_isboolean(L,3)) {
-        saveToProfile = lua_toboolean(L,3);
-        if( saveToProfile ) {
-            qDebug() << "TLuaInterpreter::connectToProfile(" << url.c_str() << ", " << port << ", " << saveToProfile << ")";
-
-            const QString filePath("%1/.config/mudlet/profiles/%2/%3");
-            QFile urlFile( filePath.arg(QDir::homePath(), pHost->getName(), "url") );
-            QFile portFile( filePath.arg(QDir::homePath(), pHost->getName(), "port") );
-
-            if( urlFile.open(QIODevice::WriteOnly) ) {
-                QString newURL = url.c_str();
-                QDataStream ofsu(&urlFile);
-                ofsu << newURL;
-                urlFile.close();
-            } else {
-                lua_pushnil(L);
-                lua_pushstring( L, QString(" connectToServer: Save has Failed - %1").arg(urlFile.errorString()).toUtf8().constData() );
-                return 2;
-            }
-
-            if( portFile.open(QIODevice::WriteOnly) ) {
-                QString newPort = QString::number(port);
-                QDataStream ofsp(&portFile);
-                ofsp << newPort;
-                portFile.close();
-            } else {
-                lua_pushnil(L);
-                lua_pushstring( L, QString(" connectToServer: Save has Failed - %1").arg(portFile.errorString()).toUtf8().constData() );
-                return 2;
-            }
+    if (!lua_isnoneornil(L, 3)) {
+        if (!lua_isboolean(L, 3)) {
+            lua_pushfstring(L, "connectToServer: bad argument #3 type (save host name and port number as boolean expected, got %1!)", lua_typename(L, 3));
+            return lua_error(L);
+        } else {
+            isToSaveToProfile = lua_toboolean(L, 3);
         }
     }
 
-    QString _url = url.c_str();
-    pHost->mTelnet.connectIt( _url, port );
+    if (isToSaveToProfile) {
+        qDebug().nospace() << "TLuaInterpreter::connectToProfile(\"" << url.c_str() << "\", " << port << ", " << isToSaveToProfile << ")";
+
+        QPair<bool, QString> result = pHost->writeProfileData(QLatin1String("url"), url.c_str());
+        if (!result.first) {
+            lua_pushnil(L);
+            lua_pushfstring(L, "unable to save host name, reason: %s", result.second.toUtf8().constData());
+            return 2;
+        }
+
+        result = pHost->writeProfileData(QLatin1String("url"), QString::number(port));
+        if (!result.first) {
+            lua_pushnil(L);
+            lua_pushfstring(L, "unable to save port number, reason: %s", result.second.toUtf8().constData());
+            return 2;
+        }
+    }
+
+    pHost->mTelnet.connectIt(url.c_str(), port);
+
     lua_pushboolean(L, true);
     return 1;
 }


### PR DESCRIPTION
Something similar to this method was going to be introduced in a different PR by me https://github.com/Mudlet/Mudlet/pull/969 and I saw the advantage of revising that to make it suitable for this PR as well.

Have revised the original code to allow for a default 23 port number to also be optional (and to reject the IANA reserved 0 port number) and to include the currently needed null `Host` pointer check and revised the run-time error message structure.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>